### PR TITLE
修复当接口描述超过300字符时导致修改api失败的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .DS_Store
 .DS_Store?
+/.project

--- a/db.sql
+++ b/db.sql
@@ -31,7 +31,7 @@ CREATE TABLE `api` (
   `num` varchar(100) DEFAULT NULL COMMENT '接口编号',
   `url` varchar(240) DEFAULT NULL COMMENT '请求地址',
   `name` varchar(100) DEFAULT NULL COMMENT '接口名',
-  `des` varchar(300) DEFAULT NULL COMMENT '接口描述',
+  `des` text COMMENT '接口描述',
   `parameter` text COMMENT '请求参数{所有的主求参数,以json格式在此存放}',
   `memo` text COMMENT '备注',
   `re` text COMMENT '返回值',


### PR DESCRIPTION
某些时候，会在描述框里填了大段内容，提交时则会提示修改失败。但这种情况是存在的，检查发现是api表的des字段长度限制为varchar(300)很容易就超了，所以修改为text了。